### PR TITLE
#20 Add swagger.

### DIFF
--- a/role-service/build.gradle
+++ b/role-service/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'net.lbruun.springboot:preliquibase-spring-boot-autoconfigure:1.5.1'
     implementation 'org.projectlombok:lombok:1.18.22'
     testImplementation 'com.h2database:h2'
-
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
 
     compileOnly 'org.projectlombok:lombok'

--- a/role-service/src/main/java/qreol/project/roleservice/config/ApplicationConfig.java
+++ b/role-service/src/main/java/qreol/project/roleservice/config/ApplicationConfig.java
@@ -1,0 +1,23 @@
+package qreol.project.roleservice.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class ApplicationConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Role service")
+                        .description("...")
+                        .version("1.0")
+                );
+    }
+
+}

--- a/role-service/src/main/resources/application.yml
+++ b/role-service/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
     change-log: classpath:liquibase/db.changelog.yml
     enabled: true
 server:
+  forward-headers-strategy: framework
   port: 0
 eureka:
   instance:

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     implementation 'org.liquibase:liquibase-core'
     implementation 'net.lbruun.springboot:preliquibase-spring-boot-autoconfigure:1.5.1'
     implementation 'org.projectlombok:lombok:1.18.22'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
     testImplementation 'com.h2database:h2'
 
 

--- a/user-service/src/main/java/qreol/project/userservice/config/ApplicationConfig.java
+++ b/user-service/src/main/java/qreol/project/userservice/config/ApplicationConfig.java
@@ -1,0 +1,23 @@
+package qreol.project.userservice.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class ApplicationConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("User service")
+                        .description("...")
+                        .version("1.0")
+                );
+    }
+
+}

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
     change-log: classpath:liquibase/db.changelog.yml
     enabled: true
 server:
+  forward-headers-strategy: framework
   port: 0
 eureka:
   instance:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces OpenAPI documentation support for both `role-service` and `user-service`, updating their configurations and dependencies in `application.yml` and `build.gradle` files. It also adds new `ApplicationConfig` classes to define OpenAPI beans for both services.

### Detailed summary
- Added `forward-headers-strategy: framework` to `application.yml` in both `role-service` and `user-service`.
- Updated `build.gradle` in `role-service` to include `springdoc-openapi-starter-webmvc-ui:2.6.0`.
- Updated `build.gradle` in `user-service` to include `spring-cloud-starter-openfeign` and `springdoc-openapi-starter-webmvc-ui:2.6.0`.
- Created `ApplicationConfig` class in `role-service` to define an OpenAPI bean.
- Created `ApplicationConfig` class in `user-service` to define an OpenAPI bean.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->